### PR TITLE
remove macro from gigasecond

### DIFF
--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -20,7 +20,4 @@ datetime("uuuu-MM-ddTHH:mm:ss.sssssssss")
 
 Note that the nanosecond part (`.sssssssss`) is optional, but the rest is not.
 
-A new macro, `adjusteddatetime`, is defined that accepts either a date-only literal `"YYYY-MM-DD"` or a full datetime literal `"YYYY-MM-DDTHH:mm:ss"`. 
-For a date-only literal, `"T00:00:00"` is appended, and in both cases the macro calls `datetime`.
-
 [time]: https://lean-lang.org/doc/api/Std/Time.html

--- a/exercises/practice/gigasecond/GigasecondTest.lean
+++ b/exercises/practice/gigasecond/GigasecondTest.lean
@@ -7,44 +7,18 @@ open LeanTest
 open Lean
 open Std.Time
 
-/--
-`adjusteddatetime("YYYY-MM-DD")` or `adjusteddatetime("YYYY-MM-DDTHH:mm:ss")`
-
-Accepts either:
-1. a full ISO-8601 datetime, or
-2. a date only, which is interpreted as midnight (`00:00:00`).
-
-The literal is checked at compile time.
-
-This macro makes use of the already defined `datetime` macro, inside `Std.Time`.
--/
-
-syntax "adjusteddatetime" "(" str ")" : term
-
-macro_rules
-  | `(adjusteddatetime($s:str)) => do
-      let raw := s.getString
-
-      let full :=
-        if raw.contains 'T'
-        then raw
-        else raw ++ "T00:00:00"
-
-      let lit := Syntax.mkStrLit full
-      `(datetime($lit))
-
 def gigasecondTests : TestSuite :=
   (TestSuite.empty "Gigasecond")
   |>.addTest "date only specification of time" (do
-      return assertEqual datetime("2043-01-01T01:46:40") (Gigasecond.add adjusteddatetime("2011-04-25")))
+      return assertEqual datetime("2043-01-01T01:46:40") (Gigasecond.add datetime("2011-04-25T00:00:00")))
   |>.addTest "second test for date only specification of time" (do
-      return assertEqual datetime("2009-02-19T01:46:40") (Gigasecond.add adjusteddatetime("1977-06-13")))
+      return assertEqual datetime("2009-02-19T01:46:40") (Gigasecond.add datetime("1977-06-13T00:00:00")))
   |>.addTest "third test for date only specification of time" (do
-      return assertEqual datetime("1991-03-27T01:46:40") (Gigasecond.add adjusteddatetime("1959-07-19")))
+      return assertEqual datetime("1991-03-27T01:46:40") (Gigasecond.add datetime("1959-07-19T00:00:00")))
   |>.addTest "full time specified" (do
-      return assertEqual datetime("2046-10-02T23:46:40") (Gigasecond.add adjusteddatetime("2015-01-24T22:00:00")))
+      return assertEqual datetime("2046-10-02T23:46:40") (Gigasecond.add datetime("2015-01-24T22:00:00")))
   |>.addTest "full time with day roll-over" (do
-      return assertEqual datetime("2046-10-03T01:46:39") (Gigasecond.add adjusteddatetime("2015-01-24T23:59:59")))
+      return assertEqual datetime("2046-10-03T01:46:39") (Gigasecond.add datetime("2015-01-24T23:59:59")))
 
 def main : IO UInt32 := do
   runTestSuitesWithExitCode [gigasecondTests]

--- a/generators/Generator/Generator/GigasecondGenerator.lean
+++ b/generators/Generator/Generator/GigasecondGenerator.lean
@@ -17,42 +17,17 @@ open LeanTest
 open Lean
 open Std.Time
 
-/--
-`adjusteddatetime(\"YYYY-MM-DD\")` or `adjusteddatetime(\"YYYY-MM-DDTHH:mm:ss\")`
-
-Accepts either:
-1. a full ISO-8601 datetime, or
-2. a date only, which is interpreted as midnight (`00:00:00`).
-
-The literal is checked at compile time.
-
-This macro makes use of the already defined `datetime` macro, inside Std.Time.
--/
-
-syntax \"adjusteddatetime\" \"(\" str \")\" : term
-
-macro_rules
-  | `(adjusteddatetime($s:str)) => do
-      let raw := s.getString
-
-      let full :=
-        if raw.contains 'T'
-        then raw
-        else raw ++ \"T00:00:00\"
-
-      let lit := Syntax.mkStrLit full
-      `(datetime($lit))
-
 def {exercise.decapitalize}Tests : TestSuite :=
   (TestSuite.empty \"{exercise}\")"
 
 def genTestCase (exercise : String) (case : TreeMap.Raw String Json) : String :=
-  let input := case.get! "input"
+  let input := toLiteral <| insertAllInputs <| case.get! "input"
   let expected := case.get! "expected"
   let description := case.get! "description"
               |> (·.compress)
   let funName := getFunName (case.get! "property")
-  let call := s!"({exercise}.{funName} adjusteddatetime({insertAllInputs input}))"
+  let adjustedInput := if !input.contains 'T' then s!"\"{input ++ "T00:00:00"}\"" else s!"\"{input}\""
+  let call := s!"({exercise}.{funName} datetime({adjustedInput}))"
   s!"
   |>.addTest {description} (do
       return assertEqual datetime({expected}) {call})"


### PR DESCRIPTION
This removes the macro from the test file in `Gigasecond`.

When testing the exercise on the website, I noticed the tests were timing out. I reproduced the error locally by running `./bin/verify-exercises-in-docker`. 

For some reason, it seems the macro was generating an infinite loop or something to the same effect. Once the macro was removed, the exercise started working as expected.