### PR TITLE
make gigasecond wip

### DIFF
--- a/config.json
+++ b/config.json
@@ -232,7 +232,8 @@
         "uuid": "093a5dd4-a0ab-4e22-a9f8-0411b27d710c",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 3
+        "difficulty": 3,
+        "status": "wip"
       },
       {
         "slug": "line-up",

--- a/exercises/practice/gigasecond/GigasecondTest.lean
+++ b/exercises/practice/gigasecond/GigasecondTest.lean
@@ -1,24 +1,21 @@
 import LeanTest
-import Std
-import Lean
 import Gigasecond
+import Std.Time
 
 open LeanTest
-open Lean
-open Std.Time
 
 def gigasecondTests : TestSuite :=
   (TestSuite.empty "Gigasecond")
   |>.addTest "date only specification of time" (do
-      return assertEqual (PlainDateTime.mk (PlainDate.mk 2043 1 1 (by decide)) (PlainTime.mk 1 46 40 0)) (Gigasecond.add (PlainDateTime.mk (PlainDate.mk 2011 4 25 (by decide)) (PlainTime.mk 0 0 0 0))))
+      return assertEqual (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 2043 1 1 (by decide)) (Std.Time.PlainTime.mk 1 46 40 0)) (Gigasecond.add (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 2011 4 25 (by decide)) (Std.Time.PlainTime.mk 0 0 0 0))))
   |>.addTest "second test for date only specification of time" (do
-      return assertEqual (PlainDateTime.mk (PlainDate.mk 2009 2 19 (by decide)) (PlainTime.mk 1 46 40 0)) (Gigasecond.add (PlainDateTime.mk (PlainDate.mk 1977 6 13 (by decide)) (PlainTime.mk 0 0 0 0))))
+      return assertEqual (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 2009 2 19 (by decide)) (Std.Time.PlainTime.mk 1 46 40 0)) (Gigasecond.add (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 1977 6 13 (by decide)) (Std.Time.PlainTime.mk 0 0 0 0))))
   |>.addTest "third test for date only specification of time" (do
-      return assertEqual (PlainDateTime.mk (PlainDate.mk 1991 3 27 (by decide)) (PlainTime.mk 1 46 40 0)) (Gigasecond.add (PlainDateTime.mk (PlainDate.mk 1959 7 19 (by decide)) (PlainTime.mk 0 0 0 0))))
+      return assertEqual (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 1991 3 27 (by decide)) (Std.Time.PlainTime.mk 1 46 40 0)) (Gigasecond.add (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 1959 7 19 (by decide)) (Std.Time.PlainTime.mk 0 0 0 0))))
   |>.addTest "full time specified" (do
-      return assertEqual (PlainDateTime.mk (PlainDate.mk 2046 10 2 (by decide)) (PlainTime.mk 23 46 40 0)) (Gigasecond.add (PlainDateTime.mk (PlainDate.mk 2015 1 24 (by decide)) (PlainTime.mk 22 0 0 0))))
+      return assertEqual (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 2046 10 2 (by decide)) (Std.Time.PlainTime.mk 23 46 40 0)) (Gigasecond.add (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 2015 1 24 (by decide)) (Std.Time.PlainTime.mk 22 0 0 0))))
   |>.addTest "full time with day roll-over" (do
-      return assertEqual (PlainDateTime.mk (PlainDate.mk 2046 10 3 (by decide)) (PlainTime.mk 1 46 39 0)) (Gigasecond.add (PlainDateTime.mk (PlainDate.mk 2015 1 24 (by decide)) (PlainTime.mk 23 59 59 0))))
+      return assertEqual (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 2046 10 3 (by decide)) (Std.Time.PlainTime.mk 1 46 39 0)) (Gigasecond.add (Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk 2015 1 24 (by decide)) (Std.Time.PlainTime.mk 23 59 59 0))))
 
 def main : IO UInt32 := do
   runTestSuitesWithExitCode [gigasecondTests]

--- a/generators/Generator/Generator/GigasecondGenerator.lean
+++ b/generators/Generator/Generator/GigasecondGenerator.lean
@@ -9,13 +9,10 @@ open Helper
 namespace GigasecondGenerator
 
 def genIntro (exercise : String) : String := s!"import LeanTest
-import Std
-import Lean
 import {exercise}
+import Std.Time
 
 open LeanTest
-open Lean
-open Std.Time
 
 def {exercise.decapitalize}Tests : TestSuite :=
   (TestSuite.empty \"{exercise}\")"
@@ -52,7 +49,7 @@ def parseInput : List Char → Option DateTimeValues
   | _ => none
 
 def toPlainDateTime (values : DateTimeValues) : String :=
-  s!"PlainDateTime.mk (PlainDate.mk {values.year} {values.month} {values.day} (by decide)) (PlainTime.mk {values.hour} {values.minute} {values.second} 0)"
+  s!"Std.Time.PlainDateTime.mk (Std.Time.PlainDate.mk {values.year} {values.month} {values.day} (by decide)) (Std.Time.PlainTime.mk {values.hour} {values.minute} {values.second} 0)"
 
 def genTestCase (exercise : String) (case : TreeMap.Raw String Json) : String :=
   let input := String.toList <| toLiteral <| insertAllInputs <| case.get! "input"


### PR DESCRIPTION
Makes `gigasecond` wip until we can find a solution to it timing out in the online editor. Also makes some small changes in the imports of the test file, just in case it makes a difference.