### PR TITLE
improve error handling by the generator

### DIFF
--- a/generators/GenerateTestFile.lean
+++ b/generators/GenerateTestFile.lean
@@ -54,9 +54,7 @@ def getPath (exercise : String) : IO String := do
       List.head!
     return s!"{directory}/exercises/{exercise}"
   catch _ =>
-    let _ ← IO.Process.run {
-      cmd := "bin/fetch-configlet"
-    }
+    fetchConfiglet
     let info ← IO.Process.run {
       cmd := "bin/configlet",
       args := #["info", "-o", "-v", "d"]


### PR DESCRIPTION
1. Added many extra messages, detailing the steps of what the generator found/not found, what it is doing and if it had any error or a successful outcome. Whenever possible, the generator continues execution, only reporting the problem to the user. For example, the absence of extra cases is reported, as is the presence of invalid JSON, but execution continues with canonical data. Execution stops only if both canonical data/toml and extra cases weren't found/couldn't be parsed.
2. If user tries to generate a test file and no configlet is found, the generator now fetches configlet first and then retries instead of throwing an error right away.