### PR TITLE
add custom exercise `reverse-list`

### DIFF
--- a/config.json
+++ b/config.json
@@ -275,6 +275,14 @@
         "difficulty": 3
       },
       {
+        "slug": "reverse-list",
+        "name": "reverse-list",
+        "uuid": "367e9ad0-d3a1-403a-9c05-fc53a246c63b",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "rotational-cipher",
         "name": "Rotational Cipher",
         "uuid": "014d61d3-07ae-42fe-9305-5979394a86c0",

--- a/exercises/practice/reverse-list/.docs/instructions.md
+++ b/exercises/practice/reverse-list/.docs/instructions.md
@@ -1,0 +1,17 @@
+# Instructions
+
+Your task is to prove the equality between a custom list reversing function and the built-in `List.reverse`.
+
+Due to the nature of this exercise, instead of relying on traditional runtime tests, the proof is checked by a theorem `check`.
+You may consider the test passing if this theorem typechecks.
+
+If you work locally or in Lean's [online playground][playground], you will get instant feedback on whether any theorem succeeds or fails, and why it fails, through Lean InfoView.
+It is an invaluable tool, capable of showing all local values in use by your proof, and your current goal.
+
+[playground]: https://live.lean-lang.org/
+
+~~~~exercism/caution
+The `sorry` tactic makes any proof appear to be correct. 
+For this reason, the `check` theorem might appear to automatically typecheck before any proof is actually written.
+Once you remove `sorry` from your proof, Lean InfoView will show the correct feedback.
+~~~~

--- a/exercises/practice/reverse-list/.meta/Example.lean
+++ b/exercises/practice/reverse-list/.meta/Example.lean
@@ -1,0 +1,13 @@
+import Spec
+
+namespace ReverseList
+
+@[csimp]
+theorem custom_reverse_eq_spec_reverse : @Spec.custom_reverse = @List.reverse := by
+  funext α
+  funext xs
+  induction xs with
+  | nil         => rfl
+  | cons x xs' ir => simpa [Spec.custom_reverse, List.reverse_cons] using ir
+
+end ReverseList

--- a/exercises/practice/reverse-list/.meta/config.json
+++ b/exercises/practice/reverse-list/.meta/config.json
@@ -1,0 +1,21 @@
+{
+  "authors": [
+    "oxe-i"
+  ],
+  "files": {
+    "solution": [
+      "ReverseList.lean"
+    ],
+    "test": [
+      "ReverseListTest.lean"
+    ],
+    "example": [
+      ".meta/Example.lean"
+    ],
+    "editor": [
+      "Spec.lean"
+    ]
+  },
+  "icon": "array-loops",
+  "blurb": "Prove equality between a custom function and the built-in List.reverse function."
+}

--- a/exercises/practice/reverse-list/ReverseList.lean
+++ b/exercises/practice/reverse-list/ReverseList.lean
@@ -1,0 +1,9 @@
+import Spec
+
+namespace ReverseList
+
+@[csimp]
+theorem custom_reverse_eq_spec_reverse: @Spec.custom_reverse = @List.reverse := by
+  sorry --remove this line and implement the proof
+
+end ReverseList

--- a/exercises/practice/reverse-list/ReverseListTest.lean
+++ b/exercises/practice/reverse-list/ReverseListTest.lean
@@ -1,0 +1,10 @@
+import LeanTest
+import ReverseList
+
+open LeanTest
+
+theorem check: @Spec.custom_reverse = @List.reverse := by
+  exact ReverseList.custom_reverse_eq_spec_reverse
+
+def main : IO UInt32 := do
+  runTestSuitesWithExitCode []

--- a/exercises/practice/reverse-list/Spec.lean
+++ b/exercises/practice/reverse-list/Spec.lean
@@ -1,0 +1,7 @@
+namespace Spec
+
+def custom_reverse {α : Type u} : List α → List α
+  | []      => []
+  | x :: xs => custom_reverse xs ++ [x]
+
+end Spec

--- a/exercises/practice/reverse-list/lakefile.toml
+++ b/exercises/practice/reverse-list/lakefile.toml
@@ -1,0 +1,20 @@
+name = "reverse-list"
+version = "0.1.0"
+defaultTargets = ["ReverseListTest"]
+testDriver = "ReverseListTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
+
+[[lean_lib]]
+name = "LeanTest"
+srcDir = "vendor/LeanTest"
+
+[[lean_lib]]
+name = "ReverseList"
+
+[[lean_lib]]
+name = "Spec"
+
+[[lean_exe]]
+name = "ReverseListTest"
+root = "ReverseListTest"
+

--- a/exercises/practice/reverse-list/lean-toolchain
+++ b/exercises/practice/reverse-list/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.29.0

--- a/exercises/practice/reverse-list/vendor/LeanTest/LeanTest.lean
+++ b/exercises/practice/reverse-list/vendor/LeanTest/LeanTest.lean
@@ -1,0 +1,4 @@
+-- This module serves as the root of the `LeanTest` library.
+-- Import modules here that should be built as part of the library.
+import LeanTest.Assertions
+import LeanTest.Test

--- a/exercises/practice/reverse-list/vendor/LeanTest/LeanTest/Assertions.lean
+++ b/exercises/practice/reverse-list/vendor/LeanTest/LeanTest/Assertions.lean
@@ -1,0 +1,166 @@
+/-
+Assertion functions for unit testing.
+-/
+
+namespace LeanTest
+
+/-- Result of a test assertion -/
+inductive AssertionResult where
+  | success : AssertionResult
+  | failure (message : String) : AssertionResult
+  deriving Repr, BEq
+
+namespace AssertionResult
+
+def isSuccess : AssertionResult → Bool
+  | success => true
+  | failure _ => false
+
+def getMessage : AssertionResult → String
+  | success => "Assertion passed"
+  | failure msg => msg
+
+end AssertionResult
+
+/-- Assert that a boolean condition is true -/
+def assert (condition : Bool) (message : String := "Assertion failed") : AssertionResult :=
+  if condition then
+    .success
+  else
+    .failure message
+
+/-- Assert that two values are equal -/
+def assertEqual [BEq α] [Repr α] (expected : α) (actual : α) (message : String := "") : AssertionResult :=
+  if expected == actual then
+    .success
+  else
+    let msg := if message.isEmpty then
+      s!"Expected: {repr expected}\nActual: {repr actual}"
+    else
+      s!"{message}\nExpected: {repr expected}\nActual: {repr actual}"
+    .failure msg
+
+/-- Assert that two values are not equal -/
+def assertNotEqual [BEq α] [Repr α] (expected : α) (actual : α) (message : String := "") : AssertionResult :=
+  if expected != actual then
+    .success
+  else
+    let msg := if message.isEmpty then
+      s!"Expected values to be different, but both were: {repr expected}"
+    else
+      s!"{message}\nExpected values to be different, but both were: {repr expected}"
+    .failure msg
+
+/-- Refute that a boolean condition is true (assert it's false) -/
+def refute (condition : Bool) (message : String := "Refute failed - condition was true") : AssertionResult :=
+  if !condition then
+    .success
+  else
+    .failure message
+
+/-- Assert that a value is true -/
+def assertTrue (value : Bool) (message : String := "Expected true but got false") : AssertionResult :=
+  assert value message
+
+/-- Assert that a value is false -/
+def assertFalse (value : Bool) (message : String := "Expected false but got true") : AssertionResult :=
+  refute value message
+
+/-- Assert that an Option is some -/
+def assertSome [Repr α] (opt : Option α) (message : String := "Expected Some but got None") : AssertionResult :=
+  match opt with
+  | some _ => .success
+  | none => .failure message
+
+/-- Assert that an Option is none -/
+def assertNone [Repr α] (opt : Option α) (message : String := "") : AssertionResult :=
+  match opt with
+  | none => .success
+  | some val =>
+    let msg := if message.isEmpty then
+      s!"Expected None but got Some: {repr val}"
+    else
+      s!"{message}\nExpected None but got Some: {repr val}"
+    .failure msg
+
+/-- Assert that a list is empty -/
+def assertEmpty [Repr α] (list : List α) (message : String := "") : AssertionResult :=
+  match list with
+  | [] => .success
+  | _ =>
+    let msg := if message.isEmpty then
+      s!"Expected empty list but got: {repr list}"
+    else
+      s!"{message}\nExpected empty list but got: {repr list}"
+    .failure msg
+
+/-- Assert that a list contains an element -/
+def assertContains [BEq α] [Repr α] (list : List α) (element : α) (message : String := "") : AssertionResult :=
+  if list.contains element then
+    .success
+  else
+    let msg := if message.isEmpty then
+      s!"Expected list to contain {repr element}\nList: {repr list}"
+    else
+      s!"{message}\nExpected list to contain {repr element}\nList: {repr list}"
+    .failure msg
+
+/-- Assert that a value is within a range (inclusive) -/
+def assertInRange [LE α] [DecidableRel (· ≤ · : α → α → Prop)] [Repr α]
+    (value : α) (min : α) (max : α) (message : String := "") : AssertionResult :=
+  if min ≤ value ∧ value ≤ max then
+    .success
+  else
+    let msg := if message.isEmpty then
+      s!"Expected {repr value} to be in range [{repr min}, {repr max}]"
+    else
+      s!"{message}\nExpected {repr value} to be in range [{repr min}, {repr max}]"
+    .failure msg
+
+/-- Assert that an Except value is an error -/
+def assertError [Repr ε] [Repr α] (result : Except ε α) (message : String := "") : AssertionResult :=
+  match result with
+  | .error _ => .success
+  | .ok val =>
+    let msg := if message.isEmpty then
+      s!"Expected error but got Ok: {repr val}"
+    else
+      s!"{message}\nExpected error but got Ok: {repr val}"
+    .failure msg
+
+/-- Assert that an Except value is ok -/
+def assertOk [Repr ε] [Repr α] (result : Except ε α) (message : String := "") : AssertionResult :=
+  match result with
+  | .ok _ => .success
+  | .error err =>
+    let msg := if message.isEmpty then
+      s!"Expected Ok but got error: {repr err}"
+    else
+      s!"{message}\nExpected Ok but got error: {repr err}"
+    .failure msg
+
+/-- Assert that an IO action throws an error -/
+def assertThrows (action : IO α) (message : String := "") : IO AssertionResult := do
+  try
+    let _ ← action
+    let msg := if message.isEmpty then
+      "Expected IO action to throw an error, but it succeeded"
+    else
+      s!"{message}\nExpected IO action to throw an error, but it succeeded"
+    return .failure msg
+  catch _ =>
+    return .success
+
+/-- Assert that an IO action succeeds (doesn't throw) -/
+def assertSucceeds (action : IO α) (message : String := "") : IO AssertionResult := do
+  try
+    let _ ← action
+    return .success
+  catch e =>
+    let msg := if message.isEmpty then
+      s!"Expected IO action to succeed, but it threw: {e}"
+    else
+      s!"{message}\nExpected IO action to succeed, but it threw: {e}"
+    return .failure msg
+
+end LeanTest

--- a/exercises/practice/reverse-list/vendor/LeanTest/LeanTest/Test.lean
+++ b/exercises/practice/reverse-list/vendor/LeanTest/LeanTest/Test.lean
@@ -1,0 +1,130 @@
+/-
+Test case and test suite management.
+-/
+
+import LeanTest.Assertions
+
+namespace LeanTest
+
+/-- A single test case -/
+structure TestCase where
+  description : String
+  test : IO AssertionResult
+  deriving Inhabited
+
+/-- Result of running a test -/
+structure TestResult where
+  description : String
+  result : AssertionResult
+  deriving Repr
+
+/-- A collection of tests (test suite) -/
+structure TestSuite where
+  name : String
+  tests : List TestCase
+  deriving Inhabited
+
+namespace TestSuite
+
+/-- Create an empty test suite -/
+def empty (name : String) : TestSuite :=
+  { name := name, tests := [] }
+
+/-- Add a test to the suite -/
+def addTest (suite : TestSuite) (description : String) (test : IO AssertionResult) : TestSuite :=
+  { suite with tests := suite.tests ++ [{ description := description, test := test }] }
+
+end TestSuite
+
+/-- Test statistics -/
+structure TestStats where
+  total : Nat
+  passed : Nat
+  failed : Nat
+  deriving Repr
+
+namespace TestStats
+
+def empty : TestStats :=
+  { total := 0, passed := 0, failed := 0 }
+
+def addResult (stats : TestStats) (result : AssertionResult) : TestStats :=
+  { total := stats.total + 1
+  , passed := if result.isSuccess then stats.passed + 1 else stats.passed
+  , failed := if result.isSuccess then stats.failed else stats.failed + 1
+  }
+
+end TestStats
+
+/-- ANSI color codes for terminal output -/
+def greenColor : String := "\x1b[32m"
+def redColor : String := "\x1b[31m"
+def yellowColor : String := "\x1b[33m"
+def resetColor : String := "\x1b[0m"
+def boldColor : String := "\x1b[1m"
+
+/-- Run a single test and print the result -/
+def runTest (testCase : TestCase) : IO TestResult := do
+  let result ← testCase.test
+  match result with
+  | .success =>
+    IO.println s!"  {greenColor}✓{resetColor} {testCase.description}"
+  | .failure msg =>
+    IO.println s!"  {redColor}✗{resetColor} {testCase.description}"
+    IO.println s!"    {redColor}{msg}{resetColor}"
+  return { description := testCase.description, result := result }
+
+/-- Run all tests in a test suite -/
+def runTestSuite (suite : TestSuite) : IO TestStats := do
+  IO.println s!"\n{boldColor}{suite.name}{resetColor}"
+  let mut stats := TestStats.empty
+
+  for testCase in suite.tests do
+    let result ← runTest testCase
+    stats := stats.addResult result.result
+
+  return stats
+
+/-- Print test summary -/
+def printSummary (stats : TestStats) : IO Unit := do
+  IO.println ""
+  IO.println s!"{boldColor}Test Summary:{resetColor}"
+  IO.println s!"  Total:  {stats.total}"
+  IO.println s!"  {greenColor}Passed: {stats.passed}{resetColor}"
+
+  if stats.failed > 0 then
+    IO.println s!"  {redColor}Failed: {stats.failed}{resetColor}"
+    IO.println s!"\n{redColor}FAILED{resetColor}"
+  else
+    IO.println s!"\n{greenColor}ALL TESTS PASSED{resetColor}"
+
+/-- Run multiple test suites -/
+def runTestSuites (suites : List TestSuite) : IO Unit := do
+  let mut totalStats := TestStats.empty
+
+  for suite in suites do
+    let stats ← runTestSuite suite
+    totalStats := {
+      total := totalStats.total + stats.total,
+      passed := totalStats.passed + stats.passed,
+      failed := totalStats.failed + stats.failed
+    }
+
+  printSummary totalStats
+
+/-- Run multiple test suites and return exit code (0 = all passed, 1 = some failed) -/
+def runTestSuitesWithExitCode (suites : List TestSuite) : IO UInt32 := do
+  let mut totalStats := TestStats.empty
+
+  for suite in suites do
+    let stats ← runTestSuite suite
+    totalStats := {
+      total := totalStats.total + stats.total,
+      passed := totalStats.passed + stats.passed,
+      failed := totalStats.failed + stats.failed
+    }
+
+  printSummary totalStats
+  return if totalStats.failed > 0 then 1 else 0
+
+end LeanTest

--- a/generators/GenerateTestFile.lean
+++ b/generators/GenerateTestFile.lean
@@ -77,7 +77,7 @@ structure OrderedMap where
   order : Array String
   map : TreeMap.Raw String Json
 
-def empty : OrderedMap := { order := #[], map := .empty }
+def OrderedMap.empty : OrderedMap := { order := #[], map := .empty }
 
 def getOk {α β} (except : Except α β) [Inhabited β] : β := except.toOption |> Option.get!
 
@@ -290,12 +290,19 @@ def generateTestFile (exercise : String) : IO Unit := do
   match maybeToml with
   | .error msg =>
     if extra.isEmpty
-    then throw <| IO.userError s!"{msg} and no extra cases found."
+    then
+      IO.eprintln s!"{msg} and no extra cases found."
+      match genTestFileContent pascalExercise OrderedMap.empty #[] with
+      | .error msg =>
+        IO.eprintln msg
+      | .ok testContent =>
+        IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
+        IO.println s!"Added intro and ending."
     else
       IO.eprintln s!"{msg}. Trying to add extra cases."
-      match genTestFileContent pascalExercise empty extra with
+      match genTestFileContent pascalExercise OrderedMap.empty extra with
       | .error msg =>
-        throw <| IO.userError msg
+        IO.eprintln msg
       | .ok testContent =>
         IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
         IO.println "Extra cases successfully added."
@@ -304,12 +311,19 @@ def generateTestFile (exercise : String) : IO Unit := do
     match ← readCanonicalData exercise with
     | .error msg =>
       if extra.isEmpty
-      then throw <| IO.userError s!"{msg} and no extra cases found."
+      then
+        IO.eprintln s!"{msg} and no extra cases found."
+        match genTestFileContent pascalExercise OrderedMap.empty #[] with
+        | .error msg =>
+          IO.eprintln msg
+        | .ok testContent =>
+          IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
+          IO.println s!"Added intro and ending."
       else
         IO.eprintln s!"{msg}. Trying to add extra cases."
-        match genTestFileContent pascalExercise empty extra with
+        match genTestFileContent pascalExercise OrderedMap.empty extra with
         | .error msg =>
-          throw <| IO.userError msg
+          IO.eprintln msg
         | .ok testContent =>
           IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
           IO.println "Extra cases successfully added."
@@ -317,12 +331,19 @@ def generateTestFile (exercise : String) : IO Unit := do
       match canonicalData.getObj? with
       | .error _ =>
         if extra.isEmpty
-        then throw <| IO.userError "Canonical data could not be parsed and no extra cases found."
+        then
+          IO.eprintln "Canonical data could not be parsed and no extra cases found."
+          match genTestFileContent pascalExercise OrderedMap.empty #[] with
+          | .error msg =>
+            IO.eprintln msg
+          | .ok testContent =>
+            IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
+            IO.println s!"Added intro and ending."
         else
           IO.eprintln s!"Canonical data could not be parsed. Trying to add extra cases."
-          match genTestFileContent pascalExercise empty extra with
+          match genTestFileContent pascalExercise OrderedMap.empty extra with
           | .error msg =>
-            throw <| IO.userError msg
+            IO.eprintln msg
           | .ok testContent =>
             IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
             IO.println "Extra cases successfully added."
@@ -330,19 +351,26 @@ def generateTestFile (exercise : String) : IO Unit := do
         match getCanonicalCases maybeMap tests with
         | .error msg =>
           if extra.isEmpty
-          then throw <| IO.userError s!"{msg} and no extra cases found."
+          then
+            IO.eprintln s!"{msg} and no extra cases found."
+            match genTestFileContent pascalExercise OrderedMap.empty #[] with
+            | .error msg =>
+              IO.eprintln msg
+            | .ok testContent =>
+              IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
+              IO.println s!"Added intro and ending."
           else
             IO.eprintln s!"Parsing canonical data returned error: {msg}. Trying to add extra cases."
-            match genTestFileContent pascalExercise empty extra with
+            match genTestFileContent pascalExercise OrderedMap.empty extra with
             | .error msg =>
-              throw <| IO.userError msg
+              IO.eprintln msg
             | .ok testContent =>
               IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
               IO.println "Extra cases successfully added."
         | .ok cases =>
           match genTestFileContent pascalExercise cases extra with
           | .error msg =>
-            throw <| IO.userError msg
+            IO.eprintln msg
           | .ok testContent =>
             IO.FS.writeFile s!"exercises/practice/{exercise}/{pascalExercise}Test.lean" testContent
             let extraMsg := if extra.isEmpty then "" else " Extra cases successfully added."

--- a/generators/Generator/Generator.lean
+++ b/generators/Generator/Generator.lean
@@ -1,3 +1,4 @@
+import Generator.ReverseListGenerator
 import Generator.ResistorColorGenerator
 import Generator.StrainGenerator
 import Generator.NucleotideCountGenerator
@@ -102,6 +103,7 @@ abbrev endBodyGenerator := String -> String
 
 def dispatch : Std.HashMap String (introGenerator × testCaseGenerator × endBodyGenerator) :=
   Std.HashMap.ofList [
+    ("ReverseList", (ReverseListGenerator.genIntro, ReverseListGenerator.genTestCase, ReverseListGenerator.genEnd)),
     ("ResistorColor", (ResistorColorGenerator.genIntro, ResistorColorGenerator.genTestCase, ResistorColorGenerator.genEnd)),
     ("Strain", (StrainGenerator.genIntro, StrainGenerator.genTestCase, StrainGenerator.genEnd)),
     ("NucleotideCount", (NucleotideCountGenerator.genIntro, NucleotideCountGenerator.genTestCase, NucleotideCountGenerator.genEnd)),

--- a/generators/Generator/Generator/ReverseListGenerator.lean
+++ b/generators/Generator/Generator/ReverseListGenerator.lean
@@ -1,0 +1,28 @@
+import Lean.Data.Json
+import Std
+import Helper
+
+open Lean
+open Std
+open Helper
+
+namespace ReverseListGenerator
+
+def genIntro (exercise : String) : String := s!"import LeanTest
+import {exercise}
+
+open LeanTest
+
+theorem check: @Spec.custom_reverse = @List.reverse := by
+  exact {exercise}.custom_reverse_eq_spec_reverse"
+
+def genTestCase (_exercise : String) (_case : TreeMap.Raw String Json) : String := ""
+
+def genEnd (_exercise : String) : String :=
+  s!"
+
+def main : IO UInt32 := do
+  runTestSuitesWithExitCode []
+"
+
+end ReverseListGenerator


### PR DESCRIPTION
1. Creates and adds a custom exercise called `reverse-list`, which aims to prove a property about a custom list reversing function (specifically, that it is equivalent to the built-in `List.reverse`).
2. Changes the generator script so that it doesn't automatically fail if an exercise has no canonical-data neither extra-cases. The script outputs this information but still builds a test file with only the intro and ending of the generator.

Right now test files used by exercises do not fail on a warning. This means that `sorry` (which is equivalent to "always true" in proofs and only emits a warning) is hard to catch. Added an extra option in `lakefile.toml` so that the build fails on any warning.

I think that maybe we should add this configuration as default in the template `lakefile.toml`. And perhaps we should also modify the test-runner so that online tests run with `--wfail` (which serves the same purpose).