### PR TITLE
set reverse-list to wip

### DIFF
--- a/config.json
+++ b/config.json
@@ -276,10 +276,11 @@
       },
       {
         "slug": "reverse-list",
-        "name": "reverse-list",
+        "name": "Reverse List",
         "uuid": "367e9ad0-d3a1-403a-9c05-fc53a246c63b",
         "practices": [],
         "prerequisites": [],
+        "status": "wip",
         "difficulty": 3
       },
       {


### PR DESCRIPTION
1. Fix name of the exercise.
2. Sets the exercise to `wip` because it needs an extra file, `Spec.lean`, which must be included in `lakefile.toml`. However, the test runner is configured so that the exercises' `lakefile.toml` is deleted and a standard `lakefile.toml` is used instead. This means right now the exercise is unsolvable, it needs some fixing on the test-runner repo first.