### PR TITLE
regenerate lakefile

### DIFF
--- a/exercises/practice/acronym/lakefile.toml
+++ b/exercises/practice/acronym/lakefile.toml
@@ -2,6 +2,7 @@ name = "acronym"
 version = "0.1.0"
 defaultTargets = ["AcronymTest"]
 testDriver = "AcronymTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Acronym"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AcronymTest"

--- a/exercises/practice/affine-cipher/lakefile.toml
+++ b/exercises/practice/affine-cipher/lakefile.toml
@@ -2,6 +2,7 @@ name = "affine-cipher"
 version = "0.1.0"
 defaultTargets = ["AffineCipherTest"]
 testDriver = "AffineCipherTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "AffineCipher"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AffineCipherTest"

--- a/exercises/practice/all-your-base/lakefile.toml
+++ b/exercises/practice/all-your-base/lakefile.toml
@@ -2,6 +2,7 @@ name = "all-your-base"
 version = "0.1.0"
 defaultTargets = ["AllYourBaseTest"]
 testDriver = "AllYourBaseTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "AllYourBase"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AllYourBaseTest"

--- a/exercises/practice/allergies/lakefile.toml
+++ b/exercises/practice/allergies/lakefile.toml
@@ -2,6 +2,7 @@ name = "allergies"
 version = "0.1.0"
 defaultTargets = ["AllergiesTest"]
 testDriver = "AllergiesTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Allergies"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AllergiesTest"

--- a/exercises/practice/alphametics/lakefile.toml
+++ b/exercises/practice/alphametics/lakefile.toml
@@ -2,6 +2,7 @@ name = "alphametics"
 version = "0.1.0"
 defaultTargets = ["AlphameticsTest"]
 testDriver = "AlphameticsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Alphametics"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AlphameticsTest"

--- a/exercises/practice/anagram/lakefile.toml
+++ b/exercises/practice/anagram/lakefile.toml
@@ -2,6 +2,7 @@ name = "anagram"
 version = "0.1.0"
 defaultTargets = ["AnagramTest"]
 testDriver = "AnagramTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Anagram"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AnagramTest"

--- a/exercises/practice/armstrong-numbers/lakefile.toml
+++ b/exercises/practice/armstrong-numbers/lakefile.toml
@@ -2,6 +2,7 @@ name = "armstrong-numbers"
 version = "0.1.0"
 defaultTargets = ["ArmstrongNumbersTest"]
 testDriver = "ArmstrongNumbersTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ArmstrongNumbers"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ArmstrongNumbersTest"

--- a/exercises/practice/assemble/lakefile.toml
+++ b/exercises/practice/assemble/lakefile.toml
@@ -2,6 +2,7 @@ name = "assemble"
 version = "0.1.0"
 defaultTargets = ["AssembleTest"]
 testDriver = "AssembleTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Assemble"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AssembleTest"

--- a/exercises/practice/atbash-cipher/lakefile.toml
+++ b/exercises/practice/atbash-cipher/lakefile.toml
@@ -2,6 +2,7 @@ name = "atbash-cipher"
 version = "0.1.0"
 defaultTargets = ["AtbashCipherTest"]
 testDriver = "AtbashCipherTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "AtbashCipher"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "AtbashCipherTest"

--- a/exercises/practice/bank-account/lakefile.toml
+++ b/exercises/practice/bank-account/lakefile.toml
@@ -2,6 +2,7 @@ name = "bank-account"
 version = "0.1.0"
 defaultTargets = ["BankAccountTest"]
 testDriver = "BankAccountTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "BankAccount"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "BankAccountTest"

--- a/exercises/practice/binary-search-tree/lakefile.toml
+++ b/exercises/practice/binary-search-tree/lakefile.toml
@@ -2,6 +2,7 @@ name = "binary-search-tree"
 version = "0.1.0"
 defaultTargets = ["BinarySearchTreeTest"]
 testDriver = "BinarySearchTreeTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "BinarySearchTree"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "BinarySearchTreeTest"

--- a/exercises/practice/binary-search/lakefile.toml
+++ b/exercises/practice/binary-search/lakefile.toml
@@ -2,6 +2,7 @@ name = "binary-search"
 version = "0.1.0"
 defaultTargets = ["BinarySearchTest"]
 testDriver = "BinarySearchTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "BinarySearch"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "BinarySearchTest"

--- a/exercises/practice/bob/lakefile.toml
+++ b/exercises/practice/bob/lakefile.toml
@@ -2,6 +2,7 @@ name = "bob"
 version = "0.1.0"
 defaultTargets = ["BobTest"]
 testDriver = "BobTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Bob"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "BobTest"

--- a/exercises/practice/book-store/lakefile.toml
+++ b/exercises/practice/book-store/lakefile.toml
@@ -2,6 +2,7 @@ name = "book-store"
 version = "0.1.0"
 defaultTargets = ["BookStoreTest"]
 testDriver = "BookStoreTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "BookStore"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "BookStoreTest"

--- a/exercises/practice/camicia/lakefile.toml
+++ b/exercises/practice/camicia/lakefile.toml
@@ -2,6 +2,7 @@ name = "camicia"
 version = "0.1.0"
 defaultTargets = ["CamiciaTest"]
 testDriver = "CamiciaTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Camicia"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "CamiciaTest"

--- a/exercises/practice/change/lakefile.toml
+++ b/exercises/practice/change/lakefile.toml
@@ -2,6 +2,7 @@ name = "change"
 version = "0.1.0"
 defaultTargets = ["ChangeTest"]
 testDriver = "ChangeTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Change"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ChangeTest"

--- a/exercises/practice/clock/lakefile.toml
+++ b/exercises/practice/clock/lakefile.toml
@@ -2,6 +2,7 @@ name = "clock"
 version = "0.1.0"
 defaultTargets = ["ClockTest"]
 testDriver = "ClockTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Clock"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ClockTest"

--- a/exercises/practice/collatz-conjecture/lakefile.toml
+++ b/exercises/practice/collatz-conjecture/lakefile.toml
@@ -2,6 +2,7 @@ name = "collatz-conjecture"
 version = "0.1.0"
 defaultTargets = ["CollatzConjectureTest"]
 testDriver = "CollatzConjectureTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "CollatzConjecture"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "CollatzConjectureTest"

--- a/exercises/practice/complex-numbers/lakefile.toml
+++ b/exercises/practice/complex-numbers/lakefile.toml
@@ -2,6 +2,7 @@ name = "complex-numbers"
 version = "0.1.0"
 defaultTargets = ["ComplexNumbersTest"]
 testDriver = "ComplexNumbersTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ComplexNumbers"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ComplexNumbersTest"

--- a/exercises/practice/connect/lakefile.toml
+++ b/exercises/practice/connect/lakefile.toml
@@ -2,6 +2,7 @@ name = "connect"
 version = "0.1.0"
 defaultTargets = ["ConnectTest"]
 testDriver = "ConnectTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Connect"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ConnectTest"

--- a/exercises/practice/crypto-square/lakefile.toml
+++ b/exercises/practice/crypto-square/lakefile.toml
@@ -2,6 +2,7 @@ name = "crypto-square"
 version = "0.1.0"
 defaultTargets = ["CryptoSquareTest"]
 testDriver = "CryptoSquareTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "CryptoSquare"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "CryptoSquareTest"

--- a/exercises/practice/custom-set/lakefile.toml
+++ b/exercises/practice/custom-set/lakefile.toml
@@ -2,6 +2,7 @@ name = "custom-set"
 version = "0.1.0"
 defaultTargets = ["CustomSetTest"]
 testDriver = "CustomSetTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "CustomSet"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "CustomSetTest"

--- a/exercises/practice/darts/lakefile.toml
+++ b/exercises/practice/darts/lakefile.toml
@@ -2,6 +2,7 @@ name = "darts"
 version = "0.1.0"
 defaultTargets = ["DartsTest"]
 testDriver = "DartsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Darts"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "DartsTest"

--- a/exercises/practice/diamond/lakefile.toml
+++ b/exercises/practice/diamond/lakefile.toml
@@ -2,6 +2,7 @@ name = "diamond"
 version = "0.1.0"
 defaultTargets = ["DiamondTest"]
 testDriver = "DiamondTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Diamond"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "DiamondTest"

--- a/exercises/practice/difference-of-squares/lakefile.toml
+++ b/exercises/practice/difference-of-squares/lakefile.toml
@@ -2,6 +2,7 @@ name = "difference-of-squares"
 version = "0.1.0"
 defaultTargets = ["DifferenceOfSquaresTest"]
 testDriver = "DifferenceOfSquaresTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "DifferenceOfSquares"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "DifferenceOfSquaresTest"

--- a/exercises/practice/dnd-character/lakefile.toml
+++ b/exercises/practice/dnd-character/lakefile.toml
@@ -2,6 +2,7 @@ name = "dnd-character"
 version = "0.1.0"
 defaultTargets = ["DndCharacterTest"]
 testDriver = "DndCharacterTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "DndCharacter"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "DndCharacterTest"

--- a/exercises/practice/dominoes/lakefile.toml
+++ b/exercises/practice/dominoes/lakefile.toml
@@ -2,6 +2,7 @@ name = "dominoes"
 version = "0.1.0"
 defaultTargets = ["DominoesTest"]
 testDriver = "DominoesTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Dominoes"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "DominoesTest"

--- a/exercises/practice/eliuds-eggs/lakefile.toml
+++ b/exercises/practice/eliuds-eggs/lakefile.toml
@@ -2,6 +2,7 @@ name = "eliuds-eggs"
 version = "0.1.0"
 defaultTargets = ["EliudsEggsTest"]
 testDriver = "EliudsEggsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "EliudsEggs"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "EliudsEggsTest"

--- a/exercises/practice/etl/lakefile.toml
+++ b/exercises/practice/etl/lakefile.toml
@@ -2,6 +2,7 @@ name = "etl"
 version = "0.1.0"
 defaultTargets = ["EtlTest"]
 testDriver = "EtlTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Etl"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "EtlTest"

--- a/exercises/practice/flatten-array/lakefile.toml
+++ b/exercises/practice/flatten-array/lakefile.toml
@@ -2,6 +2,7 @@ name = "flatten-array"
 version = "0.1.0"
 defaultTargets = ["FlattenArrayTest"]
 testDriver = "FlattenArrayTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "FlattenArray"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "FlattenArrayTest"

--- a/exercises/practice/forth/lakefile.toml
+++ b/exercises/practice/forth/lakefile.toml
@@ -2,6 +2,7 @@ name = "forth"
 version = "0.1.0"
 defaultTargets = ["ForthTest"]
 testDriver = "ForthTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Forth"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ForthTest"

--- a/exercises/practice/game-of-life/lakefile.toml
+++ b/exercises/practice/game-of-life/lakefile.toml
@@ -2,6 +2,7 @@ name = "game-of-life"
 version = "0.1.0"
 defaultTargets = ["GameOfLifeTest"]
 testDriver = "GameOfLifeTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "GameOfLife"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "GameOfLifeTest"

--- a/exercises/practice/gigasecond/lakefile.toml
+++ b/exercises/practice/gigasecond/lakefile.toml
@@ -2,6 +2,7 @@ name = "gigasecond"
 version = "0.1.0"
 defaultTargets = ["GigasecondTest"]
 testDriver = "GigasecondTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Gigasecond"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "GigasecondTest"

--- a/exercises/practice/grains/lakefile.toml
+++ b/exercises/practice/grains/lakefile.toml
@@ -2,6 +2,7 @@ name = "grains"
 version = "0.1.0"
 defaultTargets = ["GrainsTest"]
 testDriver = "GrainsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Grains"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "GrainsTest"

--- a/exercises/practice/grep/lakefile.toml
+++ b/exercises/practice/grep/lakefile.toml
@@ -2,6 +2,7 @@ name = "grep"
 version = "0.1.0"
 defaultTargets = ["GrepTest"]
 testDriver = "GrepTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Grep"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "GrepTest"

--- a/exercises/practice/hamming/lakefile.toml
+++ b/exercises/practice/hamming/lakefile.toml
@@ -2,6 +2,7 @@ name = "hamming"
 version = "0.1.0"
 defaultTargets = ["HammingTest"]
 testDriver = "HammingTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Hamming"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "HammingTest"

--- a/exercises/practice/hangman/lakefile.toml
+++ b/exercises/practice/hangman/lakefile.toml
@@ -2,6 +2,7 @@ name = "hangman"
 version = "0.1.0"
 defaultTargets = ["HangmanTest"]
 testDriver = "HangmanTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Hangman"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "HangmanTest"

--- a/exercises/practice/hello-world/lakefile.toml
+++ b/exercises/practice/hello-world/lakefile.toml
@@ -2,6 +2,7 @@ name = "hello-world"
 version = "0.1.0"
 defaultTargets = ["HelloWorldTest"]
 testDriver = "HelloWorldTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "HelloWorld"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "HelloWorldTest"

--- a/exercises/practice/high-scores/lakefile.toml
+++ b/exercises/practice/high-scores/lakefile.toml
@@ -2,6 +2,7 @@ name = "high-scores"
 version = "0.1.0"
 defaultTargets = ["HighScoresTest"]
 testDriver = "HighScoresTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "HighScores"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "HighScoresTest"

--- a/exercises/practice/house/lakefile.toml
+++ b/exercises/practice/house/lakefile.toml
@@ -2,6 +2,7 @@ name = "house"
 version = "0.1.0"
 defaultTargets = ["HouseTest"]
 testDriver = "HouseTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "House"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "HouseTest"

--- a/exercises/practice/isbn-verifier/lakefile.toml
+++ b/exercises/practice/isbn-verifier/lakefile.toml
@@ -2,6 +2,7 @@ name = "isbn-verifier"
 version = "0.1.0"
 defaultTargets = ["IsbnVerifierTest"]
 testDriver = "IsbnVerifierTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "IsbnVerifier"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "IsbnVerifierTest"

--- a/exercises/practice/isogram/lakefile.toml
+++ b/exercises/practice/isogram/lakefile.toml
@@ -2,6 +2,7 @@ name = "isogram"
 version = "0.1.0"
 defaultTargets = ["IsogramTest"]
 testDriver = "IsogramTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Isogram"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "IsogramTest"

--- a/exercises/practice/kindergarten-garden/lakefile.toml
+++ b/exercises/practice/kindergarten-garden/lakefile.toml
@@ -2,6 +2,7 @@ name = "kindergarten-garden"
 version = "0.1.0"
 defaultTargets = ["KindergartenGardenTest"]
 testDriver = "KindergartenGardenTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "KindergartenGarden"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "KindergartenGardenTest"

--- a/exercises/practice/knapsack/lakefile.toml
+++ b/exercises/practice/knapsack/lakefile.toml
@@ -2,6 +2,7 @@ name = "knapsack"
 version = "0.1.0"
 defaultTargets = ["KnapsackTest"]
 testDriver = "KnapsackTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Knapsack"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "KnapsackTest"

--- a/exercises/practice/largest-series-product/lakefile.toml
+++ b/exercises/practice/largest-series-product/lakefile.toml
@@ -2,6 +2,7 @@ name = "largest-series-product"
 version = "0.1.0"
 defaultTargets = ["LargestSeriesProductTest"]
 testDriver = "LargestSeriesProductTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "LargestSeriesProduct"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "LargestSeriesProductTest"

--- a/exercises/practice/leap/lakefile.toml
+++ b/exercises/practice/leap/lakefile.toml
@@ -2,6 +2,7 @@ name = "leap"
 version = "0.1.0"
 defaultTargets = ["LeapTest"]
 testDriver = "LeapTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Leap"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "LeapTest"

--- a/exercises/practice/line-up/lakefile.toml
+++ b/exercises/practice/line-up/lakefile.toml
@@ -2,6 +2,7 @@ name = "line-up"
 version = "0.1.0"
 defaultTargets = ["LineUpTest"]
 testDriver = "LineUpTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "LineUp"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "LineUpTest"

--- a/exercises/practice/linked-list/lakefile.toml
+++ b/exercises/practice/linked-list/lakefile.toml
@@ -2,6 +2,7 @@ name = "linked-list"
 version = "0.1.0"
 defaultTargets = ["LinkedListTest"]
 testDriver = "LinkedListTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "LinkedList"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "LinkedListTest"

--- a/exercises/practice/luhn/lakefile.toml
+++ b/exercises/practice/luhn/lakefile.toml
@@ -2,6 +2,7 @@ name = "luhn"
 version = "0.1.0"
 defaultTargets = ["LuhnTest"]
 testDriver = "LuhnTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Luhn"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "LuhnTest"

--- a/exercises/practice/matching-brackets/lakefile.toml
+++ b/exercises/practice/matching-brackets/lakefile.toml
@@ -2,6 +2,7 @@ name = "matching-brackets"
 version = "0.1.0"
 defaultTargets = ["MatchingBracketsTest"]
 testDriver = "MatchingBracketsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "MatchingBrackets"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "MatchingBracketsTest"

--- a/exercises/practice/matrix/lakefile.toml
+++ b/exercises/practice/matrix/lakefile.toml
@@ -2,6 +2,7 @@ name = "matrix"
 version = "0.1.0"
 defaultTargets = ["MatrixTest"]
 testDriver = "MatrixTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Matrix"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "MatrixTest"

--- a/exercises/practice/meetup/lakefile.toml
+++ b/exercises/practice/meetup/lakefile.toml
@@ -2,6 +2,7 @@ name = "meetup"
 version = "0.1.0"
 defaultTargets = ["MeetupTest"]
 testDriver = "MeetupTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Meetup"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "MeetupTest"

--- a/exercises/practice/nth-prime/lakefile.toml
+++ b/exercises/practice/nth-prime/lakefile.toml
@@ -2,6 +2,7 @@ name = "nth-prime"
 version = "0.1.0"
 defaultTargets = ["NthPrimeTest"]
 testDriver = "NthPrimeTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "NthPrime"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "NthPrimeTest"

--- a/exercises/practice/nucleotide-count/lakefile.toml
+++ b/exercises/practice/nucleotide-count/lakefile.toml
@@ -2,6 +2,7 @@ name = "nucleotide-count"
 version = "0.1.0"
 defaultTargets = ["NucleotideCountTest"]
 testDriver = "NucleotideCountTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "NucleotideCount"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "NucleotideCountTest"

--- a/exercises/practice/palindrome-products/lakefile.toml
+++ b/exercises/practice/palindrome-products/lakefile.toml
@@ -2,6 +2,7 @@ name = "palindrome-products"
 version = "0.1.0"
 defaultTargets = ["PalindromeProductsTest"]
 testDriver = "PalindromeProductsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "PalindromeProducts"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "PalindromeProductsTest"

--- a/exercises/practice/pangram/lakefile.toml
+++ b/exercises/practice/pangram/lakefile.toml
@@ -2,6 +2,7 @@ name = "pangram"
 version = "0.1.0"
 defaultTargets = ["PangramTest"]
 testDriver = "PangramTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Pangram"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "PangramTest"

--- a/exercises/practice/parallel-letter-frequency/lakefile.toml
+++ b/exercises/practice/parallel-letter-frequency/lakefile.toml
@@ -2,6 +2,7 @@ name = "parallel-letter-frequency"
 version = "0.1.0"
 defaultTargets = ["ParallelLetterFrequencyTest"]
 testDriver = "ParallelLetterFrequencyTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ParallelLetterFrequency"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ParallelLetterFrequencyTest"

--- a/exercises/practice/pascals-triangle/lakefile.toml
+++ b/exercises/practice/pascals-triangle/lakefile.toml
@@ -2,6 +2,7 @@ name = "pascals-triangle"
 version = "0.1.0"
 defaultTargets = ["PascalsTriangleTest"]
 testDriver = "PascalsTriangleTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "PascalsTriangle"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "PascalsTriangleTest"

--- a/exercises/practice/perfect-numbers/lakefile.toml
+++ b/exercises/practice/perfect-numbers/lakefile.toml
@@ -2,6 +2,7 @@ name = "perfect-numbers"
 version = "0.1.0"
 defaultTargets = ["PerfectNumbersTest"]
 testDriver = "PerfectNumbersTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "PerfectNumbers"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "PerfectNumbersTest"

--- a/exercises/practice/phone-number/lakefile.toml
+++ b/exercises/practice/phone-number/lakefile.toml
@@ -2,6 +2,7 @@ name = "phone-number"
 version = "0.1.0"
 defaultTargets = ["PhoneNumberTest"]
 testDriver = "PhoneNumberTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "PhoneNumber"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "PhoneNumberTest"

--- a/exercises/practice/prime-factors/lakefile.toml
+++ b/exercises/practice/prime-factors/lakefile.toml
@@ -2,6 +2,7 @@ name = "prime-factors"
 version = "0.1.0"
 defaultTargets = ["PrimeFactorsTest"]
 testDriver = "PrimeFactorsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "PrimeFactors"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "PrimeFactorsTest"

--- a/exercises/practice/protein-translation/lakefile.toml
+++ b/exercises/practice/protein-translation/lakefile.toml
@@ -2,6 +2,7 @@ name = "protein-translation"
 version = "0.1.0"
 defaultTargets = ["ProteinTranslationTest"]
 testDriver = "ProteinTranslationTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ProteinTranslation"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ProteinTranslationTest"

--- a/exercises/practice/pythagorean-triplet/lakefile.toml
+++ b/exercises/practice/pythagorean-triplet/lakefile.toml
@@ -2,6 +2,7 @@ name = "pythagorean-triplet"
 version = "0.1.0"
 defaultTargets = ["PythagoreanTripletTest"]
 testDriver = "PythagoreanTripletTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "PythagoreanTriplet"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "PythagoreanTripletTest"

--- a/exercises/practice/queen-attack/lakefile.toml
+++ b/exercises/practice/queen-attack/lakefile.toml
@@ -2,6 +2,7 @@ name = "queen-attack"
 version = "0.1.0"
 defaultTargets = ["QueenAttackTest"]
 testDriver = "QueenAttackTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "QueenAttack"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "QueenAttackTest"

--- a/exercises/practice/rail-fence-cipher/lakefile.toml
+++ b/exercises/practice/rail-fence-cipher/lakefile.toml
@@ -2,6 +2,7 @@ name = "rail-fence-cipher"
 version = "0.1.0"
 defaultTargets = ["RailFenceCipherTest"]
 testDriver = "RailFenceCipherTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "RailFenceCipher"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RailFenceCipherTest"

--- a/exercises/practice/raindrops/lakefile.toml
+++ b/exercises/practice/raindrops/lakefile.toml
@@ -2,6 +2,7 @@ name = "raindrops"
 version = "0.1.0"
 defaultTargets = ["RaindropsTest"]
 testDriver = "RaindropsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Raindrops"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RaindropsTest"

--- a/exercises/practice/rational-numbers/lakefile.toml
+++ b/exercises/practice/rational-numbers/lakefile.toml
@@ -2,6 +2,7 @@ name = "rational-numbers"
 version = "0.1.0"
 defaultTargets = ["RationalNumbersTest"]
 testDriver = "RationalNumbersTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "RationalNumbers"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RationalNumbersTest"

--- a/exercises/practice/rectangles/lakefile.toml
+++ b/exercises/practice/rectangles/lakefile.toml
@@ -2,6 +2,7 @@ name = "rectangles"
 version = "0.1.0"
 defaultTargets = ["RectanglesTest"]
 testDriver = "RectanglesTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Rectangles"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RectanglesTest"

--- a/exercises/practice/relative-distance/lakefile.toml
+++ b/exercises/practice/relative-distance/lakefile.toml
@@ -2,6 +2,7 @@ name = "relative-distance"
 version = "0.1.0"
 defaultTargets = ["RelativeDistanceTest"]
 testDriver = "RelativeDistanceTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "RelativeDistance"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RelativeDistanceTest"

--- a/exercises/practice/resistor-color-trio/lakefile.toml
+++ b/exercises/practice/resistor-color-trio/lakefile.toml
@@ -2,6 +2,7 @@ name = "resistor-color-trio"
 version = "0.1.0"
 defaultTargets = ["ResistorColorTrioTest"]
 testDriver = "ResistorColorTrioTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"

--- a/exercises/practice/resistor-color/lakefile.toml
+++ b/exercises/practice/resistor-color/lakefile.toml
@@ -2,6 +2,7 @@ name = "resistor-color"
 version = "0.1.0"
 defaultTargets = ["ResistorColorTest"]
 testDriver = "ResistorColorTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ResistorColor"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ResistorColorTest"

--- a/exercises/practice/reverse-list/lakefile.toml
+++ b/exercises/practice/reverse-list/lakefile.toml
@@ -17,4 +17,3 @@ name = "Extra"
 [[lean_exe]]
 name = "ReverseListTest"
 root = "ReverseListTest"
-

--- a/exercises/practice/reverse-string/lakefile.toml
+++ b/exercises/practice/reverse-string/lakefile.toml
@@ -2,6 +2,7 @@ name = "reverse-string"
 version = "0.1.0"
 defaultTargets = ["ReverseStringTest"]
 testDriver = "ReverseStringTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ReverseString"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ReverseStringTest"

--- a/exercises/practice/rna-transcription/lakefile.toml
+++ b/exercises/practice/rna-transcription/lakefile.toml
@@ -2,6 +2,7 @@ name = "rna-transcription"
 version = "0.1.0"
 defaultTargets = ["RnaTranscriptionTest"]
 testDriver = "RnaTranscriptionTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "RnaTranscription"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RnaTranscriptionTest"

--- a/exercises/practice/roman-numerals/lakefile.toml
+++ b/exercises/practice/roman-numerals/lakefile.toml
@@ -2,6 +2,7 @@ name = "roman-numerals"
 version = "0.1.0"
 defaultTargets = ["RomanNumeralsTest"]
 testDriver = "RomanNumeralsTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "RomanNumerals"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RomanNumeralsTest"

--- a/exercises/practice/rotational-cipher/lakefile.toml
+++ b/exercises/practice/rotational-cipher/lakefile.toml
@@ -2,6 +2,7 @@ name = "rotational-cipher"
 version = "0.1.0"
 defaultTargets = ["RotationalCipherTest"]
 testDriver = "RotationalCipherTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "RotationalCipher"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RotationalCipherTest"

--- a/exercises/practice/run-length-encoding/lakefile.toml
+++ b/exercises/practice/run-length-encoding/lakefile.toml
@@ -2,6 +2,7 @@ name = "run-length-encoding"
 version = "0.1.0"
 defaultTargets = ["RunLengthEncodingTest"]
 testDriver = "RunLengthEncodingTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "RunLengthEncoding"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "RunLengthEncodingTest"

--- a/exercises/practice/satellite/lakefile.toml
+++ b/exercises/practice/satellite/lakefile.toml
@@ -2,6 +2,7 @@ name = "satellite"
 version = "0.1.0"
 defaultTargets = ["SatelliteTest"]
 testDriver = "SatelliteTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Satellite"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SatelliteTest"

--- a/exercises/practice/say/lakefile.toml
+++ b/exercises/practice/say/lakefile.toml
@@ -2,6 +2,7 @@ name = "say"
 version = "0.1.0"
 defaultTargets = ["SayTest"]
 testDriver = "SayTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Say"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SayTest"

--- a/exercises/practice/scrabble-score/lakefile.toml
+++ b/exercises/practice/scrabble-score/lakefile.toml
@@ -2,6 +2,7 @@ name = "scrabble-score"
 version = "0.1.0"
 defaultTargets = ["ScrabbleScoreTest"]
 testDriver = "ScrabbleScoreTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ScrabbleScore"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ScrabbleScoreTest"

--- a/exercises/practice/secret-handshake/lakefile.toml
+++ b/exercises/practice/secret-handshake/lakefile.toml
@@ -2,6 +2,7 @@ name = "secret-handshake"
 version = "0.1.0"
 defaultTargets = ["SecretHandshakeTest"]
 testDriver = "SecretHandshakeTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "SecretHandshake"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SecretHandshakeTest"

--- a/exercises/practice/series/lakefile.toml
+++ b/exercises/practice/series/lakefile.toml
@@ -2,6 +2,7 @@ name = "series"
 version = "0.1.0"
 defaultTargets = ["SeriesTest"]
 testDriver = "SeriesTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Series"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SeriesTest"

--- a/exercises/practice/sgf-parsing/lakefile.toml
+++ b/exercises/practice/sgf-parsing/lakefile.toml
@@ -2,6 +2,7 @@ name = "sgf-parsing"
 version = "0.1.0"
 defaultTargets = ["SgfParsingTest"]
 testDriver = "SgfParsingTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "SgfParsing"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SgfParsingTest"

--- a/exercises/practice/space-age/lakefile.toml
+++ b/exercises/practice/space-age/lakefile.toml
@@ -2,6 +2,7 @@ name = "space-age"
 version = "0.1.0"
 defaultTargets = ["SpaceAgeTest"]
 testDriver = "SpaceAgeTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "SpaceAge"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SpaceAgeTest"

--- a/exercises/practice/square-root/lakefile.toml
+++ b/exercises/practice/square-root/lakefile.toml
@@ -2,6 +2,7 @@ name = "square-root"
 version = "0.1.0"
 defaultTargets = ["SquareRootTest"]
 testDriver = "SquareRootTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "SquareRoot"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SquareRootTest"

--- a/exercises/practice/strain/lakefile.toml
+++ b/exercises/practice/strain/lakefile.toml
@@ -2,6 +2,7 @@ name = "strain"
 version = "0.1.0"
 defaultTargets = ["StrainTest"]
 testDriver = "StrainTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Strain"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "StrainTest"

--- a/exercises/practice/sublist/lakefile.toml
+++ b/exercises/practice/sublist/lakefile.toml
@@ -2,6 +2,7 @@ name = "sublist"
 version = "0.1.0"
 defaultTargets = ["SublistTest"]
 testDriver = "SublistTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Sublist"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SublistTest"

--- a/exercises/practice/sum-of-multiples/lakefile.toml
+++ b/exercises/practice/sum-of-multiples/lakefile.toml
@@ -2,6 +2,7 @@ name = "sum-of-multiples"
 version = "0.1.0"
 defaultTargets = ["SumOfMultiplesTest"]
 testDriver = "SumOfMultiplesTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "SumOfMultiples"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "SumOfMultiplesTest"

--- a/exercises/practice/transpose/lakefile.toml
+++ b/exercises/practice/transpose/lakefile.toml
@@ -2,6 +2,7 @@ name = "transpose"
 version = "0.1.0"
 defaultTargets = ["TransposeTest"]
 testDriver = "TransposeTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Transpose"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "TransposeTest"

--- a/exercises/practice/triangle/lakefile.toml
+++ b/exercises/practice/triangle/lakefile.toml
@@ -2,6 +2,7 @@ name = "triangle"
 version = "0.1.0"
 defaultTargets = ["TriangleTest"]
 testDriver = "TriangleTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Triangle"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "TriangleTest"

--- a/exercises/practice/twelve-days/lakefile.toml
+++ b/exercises/practice/twelve-days/lakefile.toml
@@ -2,6 +2,7 @@ name = "twelve-days"
 version = "0.1.0"
 defaultTargets = ["TwelveDaysTest"]
 testDriver = "TwelveDaysTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "TwelveDays"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "TwelveDaysTest"

--- a/exercises/practice/two-bucket/lakefile.toml
+++ b/exercises/practice/two-bucket/lakefile.toml
@@ -2,6 +2,7 @@ name = "two-bucket"
 version = "0.1.0"
 defaultTargets = ["TwoBucketTest"]
 testDriver = "TwoBucketTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "TwoBucket"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "TwoBucketTest"

--- a/exercises/practice/two-fer/lakefile.toml
+++ b/exercises/practice/two-fer/lakefile.toml
@@ -2,6 +2,7 @@ name = "two-fer"
 version = "0.1.0"
 defaultTargets = ["TwoFerTest"]
 testDriver = "TwoFerTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "TwoFer"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "TwoFerTest"

--- a/exercises/practice/variable-length-quantity/lakefile.toml
+++ b/exercises/practice/variable-length-quantity/lakefile.toml
@@ -2,6 +2,7 @@ name = "variable-length-quantity"
 version = "0.1.0"
 defaultTargets = ["VariableLengthQuantityTest"]
 testDriver = "VariableLengthQuantityTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "VariableLengthQuantity"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "VariableLengthQuantityTest"

--- a/exercises/practice/word-count/lakefile.toml
+++ b/exercises/practice/word-count/lakefile.toml
@@ -2,6 +2,7 @@ name = "word-count"
 version = "0.1.0"
 defaultTargets = ["WordCountTest"]
 testDriver = "WordCountTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "WordCount"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "WordCountTest"

--- a/exercises/practice/wordy/lakefile.toml
+++ b/exercises/practice/wordy/lakefile.toml
@@ -2,6 +2,7 @@ name = "wordy"
 version = "0.1.0"
 defaultTargets = ["WordyTest"]
 testDriver = "WordyTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Wordy"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "WordyTest"

--- a/exercises/practice/yacht/lakefile.toml
+++ b/exercises/practice/yacht/lakefile.toml
@@ -2,6 +2,7 @@ name = "yacht"
 version = "0.1.0"
 defaultTargets = ["YachtTest"]
 testDriver = "YachtTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "Yacht"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "YachtTest"

--- a/exercises/practice/zebra-puzzle/lakefile.toml
+++ b/exercises/practice/zebra-puzzle/lakefile.toml
@@ -2,6 +2,7 @@ name = "zebra-puzzle"
 version = "0.1.0"
 defaultTargets = ["ZebraPuzzleTest"]
 testDriver = "ZebraPuzzleTest"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "ZebraPuzzle"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "ZebraPuzzleTest"

--- a/generators/GenerateTestFile.lean
+++ b/generators/GenerateTestFile.lean
@@ -397,17 +397,23 @@ def kebabCase (pascal : String) : String :=
     else (acc.push ch, false)
   ) ("", true) |>.fst
 
-def addTemplates (exercise : String) : IO Unit := do
-  let toolchainPath := s!"exercises/practice/{exercise}/lean-toolchain"
-  if ← System.FilePath.pathExists toolchainPath then
+def addTemplates (pascal kebab : String) : IO Unit := do
+  let paths ← System.FilePath.walkDir "templates"
+  for path in paths do
+    if ← path.isDir then continue
+    let strPath := path.toString
+    let newPath := strPath.replace "templates" s!"exercises/practice/{kebab}"
     try
-      let newToolchain ← IO.FS.readFile "templates/lean-toolchain"
-      IO.FS.writeFile toolchainPath newToolchain
+      let content ← (do
+        if strPath.trimAsciiEnd.endsWith "lakefile.toml" then
+          IO.FS.readFile path
+            >>= (return ·.replace "%{pascal_slug}" pascal)
+            >>= (return ·.replace "%{kebab_slug}" kebab)
+        else
+          IO.FS.readFile path)
+      IO.FS.writeFile newPath content
     catch _ =>
-      IO.eprintln "Couldn't find lean-toolchain in templates. Please add it manually."
-  else
-    IO.println s!"Couldn't find lean-toolchain in {toolchainPath}. Trying to add exercise"
-    addPracticeExercise exercise []
+      IO.eprintln s!"Failed to add templates to {pascal}."
 
 def regenerateTestFiles : IO Unit := do
   let _ ← IO.Process.run {
@@ -418,7 +424,7 @@ def regenerateTestFiles : IO Unit := do
     let kebab := kebabCase pascal
     try
       generateTestFile kebab
-      addTemplates kebab
+      addTemplates pascal kebab
     catch msg =>
       IO.eprintln s!"Regeneration for {pascal} failed. Error logged was: {msg}"
 

--- a/templates/lakefile.toml
+++ b/templates/lakefile.toml
@@ -2,6 +2,7 @@ name = "%{kebab_slug}"
 version = "0.1.0"
 defaultTargets = ["%{pascal_slug}Test"]
 testDriver = "%{pascal_slug}Test"
+moreLeanArgs = [ "-DwarningAsError=true" ]
 
 [[lean_lib]]
 name = "LeanTest"
@@ -9,6 +10,9 @@ srcDir = "vendor/LeanTest"
 
 [[lean_lib]]
 name = "%{pascal_slug}"
+
+[[lean_lib]]
+name = "Extra"
 
 [[lean_exe]]
 name = "%{pascal_slug}Test"


### PR DESCRIPTION
This change is mostly to update the `lakefile.toml` of all exercises to keep it in line with the online test runner. The online test runner treats warnings as errors, but this was not the default when students work locally.

I also updated the generator script so that `-r` (regenerate) now adds all files in the `templates` folder to every exercise in the  `exercises/practice` folder. Before, it was only adding the toolchain. This means we now have an easy way to propagate any change that affects all exercises (Lean version, additional modules, changes in the testing library, etc.).