### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions Append
 
+## Implementation
+
 To complete this exercise you need to define the data type `Clock`, add a `BEq` and a `ToString` instance, and implement the functions:
 
 * `create`, that takes two integers, possibly negative, representing hours and minutes respectively, and creates a valid Clock.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.